### PR TITLE
Fixes reference value

### DIFF
--- a/release-schema.json
+++ b/release-schema.json
@@ -35,7 +35,7 @@
               "type": "array",
               "id": "ID to identify the specific accruing moment in which the budget's value will be expressed.",
               "value": {
-                "$ref": "#/definitions/value"
+                "$ref": "#/definitions/Value"
               }
             }
           }


### PR DESCRIPTION
The attribute needs to be set to `Value`, as lowercase `value` generates:
```
  File "extension-mapping-sheet/venv/lib/python3.6/site-packages/jsonref.py", line 207, in _error
    cause=cause
jsonref.JsonRefError: ("Unresolvable JSON pointer: '/definitions/value'", OrderedDict([('$ref', '#/definitions/value')]))
```
Error when trying to merge with other schemas. 

https://tools.ietf.org/html/rfc6901
http://rapidjson.org/md_doc_pointer.html